### PR TITLE
Add support for Laravel 5.5

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -40,8 +40,10 @@ export default class{
             vm.$http[method](uri, vm.$fields, options).then((response) => {
                 resolve(response);
             }, (response) => {
-
-                vm.setError(response.data);
+                if (typeof response.data.errors === "object")
+                    vm.setError(response.data.errors);
+                else
+                    vm.setError(response.data);
 
                 reject(response);
 


### PR DESCRIPTION
Laravel response contains two fields: `message` and `errors`. We need `errors`.